### PR TITLE
Add fixtures for non-string argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-template": "^6.16.0",
+    "babel-types": "^6.19.0",
     "in-publish": "^2.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import template from 'babel-template';
 import syntax from 'babel-plugin-syntax-dynamic-import';
+import * as t from 'babel-types';
 
 const TYPE_IMPORT = 'Import';
 
@@ -13,8 +14,11 @@ export default () => ({
   visitor: {
     CallExpression(path) {
       if (path.node.callee.type === TYPE_IMPORT) {
+        const importArgument = path.node.arguments[0];
         const newImport = buildImport({
-          SOURCE: path.node.arguments,
+          SOURCE: (t.isStringLiteral(importArgument) || t.isTemplateLiteral(importArgument))
+            ? path.node.arguments
+            : t.templateLiteral([t.templateElement({ raw: '' }), t.templateElement({ raw: '' }, true)], path.node.arguments),
         });
         path.replaceWith(newImport);
       }

--- a/test/fixtures/dynamic-argument/expected.js
+++ b/test/fixtures/dynamic-argument/expected.js
@@ -1,4 +1,4 @@
 const MODULE = 'test-module';
 
-Promise.resolve().then(() => require(MODULE));
+Promise.resolve().then(() => require(`${ MODULE }`));
 Promise.resolve().then(() => require(`test-${ MODULE }`));

--- a/test/fixtures/non-string-argument/actual.js
+++ b/test/fixtures/non-string-argument/actual.js
@@ -1,0 +1,8 @@
+import({ 'answer': 42 });
+import(['foo', 'bar']);
+import(42);
+import(void 0);
+import(undefined);
+import(null);
+import(true);
+import(Symbol());

--- a/test/fixtures/non-string-argument/expected.js
+++ b/test/fixtures/non-string-argument/expected.js
@@ -1,0 +1,8 @@
+Promise.resolve().then(() => require(`${ { 'answer': 42 } }`));
+Promise.resolve().then(() => require(`${ ['foo', 'bar'] }`));
+Promise.resolve().then(() => require(`${ 42 }`));
+Promise.resolve().then(() => require(`${ void 0 }`));
+Promise.resolve().then(() => require(`${ undefined }`));
+Promise.resolve().then(() => require(`${ null }`));
+Promise.resolve().then(() => require(`${ true }`));
+Promise.resolve().then(() => require(`${ Symbol() }`));


### PR DESCRIPTION
According to current proposal argument should be converted to string using [`ToString`](http://www.ecma-international.org/ecma-262/7.0/index.html#sec-tostring) (see [runtime semantics](https://tc39.github.io/proposal-dynamic-import/#sec-import-call-runtime-semantics-evaluation)). I added tests for non-string arguments.

Unfortunately I had no luck fixing plugin code to make it pass these tests :(

[UPDATE] code fixed