### PR TITLE
Visit Import nodes instead of CallExpressions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,6 @@ import template from 'babel-template';
 import syntax from 'babel-plugin-syntax-dynamic-import';
 import * as t from 'babel-types';
 
-const TYPE_IMPORT = 'Import';
-
 const buildImport = template(`
   Promise.resolve().then(() => require(SOURCE))
 `);
@@ -12,16 +10,14 @@ export default () => ({
   inherits: syntax,
 
   visitor: {
-    CallExpression(path) {
-      if (path.node.callee.type === TYPE_IMPORT) {
-        const importArgument = path.node.arguments[0];
-        const newImport = buildImport({
-          SOURCE: (t.isStringLiteral(importArgument) || t.isTemplateLiteral(importArgument))
-            ? path.node.arguments
-            : t.templateLiteral([t.templateElement({ raw: '', cooked: '' }), t.templateElement({ raw: '', cooked: '' }, true)], path.node.arguments),
-        });
-        path.replaceWith(newImport);
-      }
+    Import(path) {
+      const importArguments = path.parentPath.node.arguments;
+      const newImport = buildImport({
+        SOURCE: (t.isStringLiteral(importArguments[0]) || t.isTemplateLiteral(importArguments[0]))
+          ? importArguments
+          : t.templateLiteral([t.templateElement({ raw: '', cooked: '' }), t.templateElement({ raw: '', cooked: '' }, true)], importArguments),
+      });
+      path.parentPath.replaceWith(newImport);
     },
   },
 });


### PR DESCRIPTION
Currently this plugin runs before other plugins that visit `Import` node directly (for example [`babel-plugin-import-inspector`](https://github.com/thejameskyle/babel-plugin-import-inspector) and [`babel-plugin-universal-import`](https://github.com/faceyspacey/babel-plugin-universal-import)) and completely prevents those to do their job.

