### PR TITLE
Use template and types from the babel object

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,6 @@
     "safe-publish-latest": "^1.1.1"
   },
   "dependencies": {
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "babel-template": "^6.26.0",
-    "babel-types": "^6.26.0"
+    "babel-plugin-syntax-dynamic-import": "^6.18.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,23 +1,26 @@
-import template from 'babel-template';
 import syntax from 'babel-plugin-syntax-dynamic-import';
-import * as t from 'babel-types';
 
-const buildImport = template(`
-  Promise.resolve().then(() => require(SOURCE))
-`);
+export default function ({ template, types: t }) {
+  const buildImport = template(`
+    Promise.resolve().then(() => require(SOURCE))
+  `);
 
-export default () => ({
-  inherits: syntax,
+  return {
+    inherits: syntax,
 
-  visitor: {
-    Import(path) {
-      const importArguments = path.parentPath.node.arguments;
-      const newImport = buildImport({
-        SOURCE: (t.isStringLiteral(importArguments[0]) || t.isTemplateLiteral(importArguments[0]))
-          ? importArguments
-          : t.templateLiteral([t.templateElement({ raw: '', cooked: '' }), t.templateElement({ raw: '', cooked: '' }, true)], importArguments),
-      });
-      path.parentPath.replaceWith(newImport);
+    visitor: {
+      Import(path) {
+        const importArguments = path.parentPath.node.arguments;
+        const newImport = buildImport({
+          SOURCE: (t.isStringLiteral(importArguments[0]) || t.isTemplateLiteral(importArguments[0]))
+            ? importArguments
+            : t.templateLiteral([
+              t.templateElement({ raw: '', cooked: '' }),
+              t.templateElement({ raw: '', cooked: '' }, true),
+            ], importArguments),
+        });
+        path.parentPath.replaceWith(newImport);
+      },
     },
-  },
-});
+  };
+}


### PR DESCRIPTION
This PR removes `babel-template` and `babel-types` dependencies and instead uses them directly from the `babel` object. 