### PR TITLE
[Breaking] always return a module namespace object

### DIFF
--- a/test/fixtures/basic-import/expected.es2015.js
+++ b/test/fixtures/basic-import/expected.es2015.js
@@ -1,5 +1,7 @@
 'use strict';
 
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
 var testModule = Promise.resolve().then(function () {
-  return require('test-module');
+  return _interopRequireWildcard(require('test-module'));
 });

--- a/test/fixtures/basic-import/expected.js
+++ b/test/fixtures/basic-import/expected.js
@@ -1,1 +1,3 @@
-const testModule = Promise.resolve().then(() => require('test-module'));
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+const testModule = Promise.resolve().then(() => _interopRequireWildcard(require('test-module')));

--- a/test/fixtures/chained-import/expected.es2015.js
+++ b/test/fixtures/chained-import/expected.es2015.js
@@ -1,17 +1,19 @@
 'use strict';
 
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
 Promise.resolve().then(function () {
-  return require('test-module');
+  return _interopRequireWildcard(require('test-module'));
 }).then(function () {
   return Promise.resolve().then(function () {
-    return require('test-module-2');
+    return _interopRequireWildcard(require('test-module-2'));
   });
 });
 
 Promise.all([Promise.resolve().then(function () {
-  return require('test-1');
+  return _interopRequireWildcard(require('test-1'));
 }), Promise.resolve().then(function () {
-  return require('test-2');
+  return _interopRequireWildcard(require('test-2'));
 }), Promise.resolve().then(function () {
-  return require('test-3');
+  return _interopRequireWildcard(require('test-3'));
 })]).then(function () {});

--- a/test/fixtures/chained-import/expected.js
+++ b/test/fixtures/chained-import/expected.js
@@ -1,3 +1,5 @@
-Promise.resolve().then(() => require('test-module')).then(() => Promise.resolve().then(() => require('test-module-2')));
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
-Promise.all([Promise.resolve().then(() => require('test-1')), Promise.resolve().then(() => require('test-2')), Promise.resolve().then(() => require('test-3'))]).then(() => {});
+Promise.resolve().then(() => _interopRequireWildcard(require('test-module'))).then(() => Promise.resolve().then(() => _interopRequireWildcard(require('test-module-2'))));
+
+Promise.all([Promise.resolve().then(() => _interopRequireWildcard(require('test-1'))), Promise.resolve().then(() => _interopRequireWildcard(require('test-2'))), Promise.resolve().then(() => _interopRequireWildcard(require('test-3')))]).then(() => {});

--- a/test/fixtures/dynamic-argument/expected.es2015.js
+++ b/test/fixtures/dynamic-argument/expected.es2015.js
@@ -1,10 +1,12 @@
 'use strict';
 
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
 var MODULE = Object('test-module');
 
 Promise.resolve().then(function () {
-  return require('' + String(MODULE));
+  return _interopRequireWildcard(require('' + String(MODULE)));
 });
 Promise.resolve().then(function () {
-  return require('test-' + String(MODULE));
+  return _interopRequireWildcard(require('test-' + String(MODULE)));
 });

--- a/test/fixtures/dynamic-argument/expected.js
+++ b/test/fixtures/dynamic-argument/expected.js
@@ -1,4 +1,6 @@
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
 const MODULE = Object('test-module');
 
-Promise.resolve().then(() => require(`${MODULE}`));
-Promise.resolve().then(() => require(`test-${MODULE}`));
+Promise.resolve().then(() => _interopRequireWildcard(require(`${MODULE}`)));
+Promise.resolve().then(() => _interopRequireWildcard(require(`test-${MODULE}`)));

--- a/test/fixtures/import-with-comment/expected.es2015.js
+++ b/test/fixtures/import-with-comment/expected.es2015.js
@@ -1,8 +1,10 @@
 'use strict';
 
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
 Promise.resolve().then(function () {
-  return require('my-module');
+  return _interopRequireWildcard(require('my-module'));
 });
 Promise.resolve().then(function () {
-  return require('my-module');
+  return _interopRequireWildcard(require('my-module'));
 });

--- a/test/fixtures/import-with-comment/expected.js
+++ b/test/fixtures/import-with-comment/expected.js
@@ -1,2 +1,4 @@
-Promise.resolve().then(() => require('my-module'));
-Promise.resolve().then(() => require('my-module'));
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+Promise.resolve().then(() => _interopRequireWildcard(require('my-module')));
+Promise.resolve().then(() => _interopRequireWildcard(require('my-module')));

--- a/test/fixtures/nested-import/expected.es2015.js
+++ b/test/fixtures/nested-import/expected.es2015.js
@@ -1,8 +1,10 @@
 'use strict';
 
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
 function getModule(path) {
   return Promise.resolve().then(function () {
-    return require('test-module');
+    return _interopRequireWildcard(require('test-module'));
   });
 }
 

--- a/test/fixtures/nested-import/expected.js
+++ b/test/fixtures/nested-import/expected.js
@@ -1,5 +1,7 @@
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
 function getModule(path) {
-  return Promise.resolve().then(() => require('test-module'));
+  return Promise.resolve().then(() => _interopRequireWildcard(require('test-module')));
 }
 
 getModule().then(() => {});

--- a/test/fixtures/non-string-argument/expected.es2015.js
+++ b/test/fixtures/non-string-argument/expected.es2015.js
@@ -1,26 +1,28 @@
 'use strict';
 
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
 Promise.resolve().then(function () {
-  return require('' + String({ 'answer': 42 }));
+  return _interopRequireWildcard(require('' + String({ 'answer': 42 })));
 });
 Promise.resolve().then(function () {
-  return require('' + String(['foo', 'bar']));
+  return _interopRequireWildcard(require('' + String(['foo', 'bar'])));
 });
 Promise.resolve().then(function () {
-  return require('' + 42);
+  return _interopRequireWildcard(require('' + 42));
 });
 Promise.resolve().then(function () {
-  return require('' + String(void 0));
+  return _interopRequireWildcard(require('' + String(void 0)));
 });
 Promise.resolve().then(function () {
-  return require('' + String(undefined));
+  return _interopRequireWildcard(require('' + String(undefined)));
 });
 Promise.resolve().then(function () {
-  return require('' + String(null));
+  return _interopRequireWildcard(require('' + String(null)));
 });
 Promise.resolve().then(function () {
-  return require('' + String(true));
+  return _interopRequireWildcard(require('' + String(true)));
 });
 Promise.resolve().then(function () {
-  return require('' + String(Symbol()));
+  return _interopRequireWildcard(require('' + String(Symbol())));
 });

--- a/test/fixtures/non-string-argument/expected.js
+++ b/test/fixtures/non-string-argument/expected.js
@@ -1,8 +1,10 @@
-Promise.resolve().then(() => require(`${{ 'answer': 42 }}`));
-Promise.resolve().then(() => require(`${['foo', 'bar']}`));
-Promise.resolve().then(() => require(`${42}`));
-Promise.resolve().then(() => require(`${void 0}`));
-Promise.resolve().then(() => require(`${undefined}`));
-Promise.resolve().then(() => require(`${null}`));
-Promise.resolve().then(() => require(`${true}`));
-Promise.resolve().then(() => require(`${Symbol()}`));
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+Promise.resolve().then(() => _interopRequireWildcard(require(`${{ 'answer': 42 }}`)));
+Promise.resolve().then(() => _interopRequireWildcard(require(`${['foo', 'bar']}`)));
+Promise.resolve().then(() => _interopRequireWildcard(require(`${42}`)));
+Promise.resolve().then(() => _interopRequireWildcard(require(`${void 0}`)));
+Promise.resolve().then(() => _interopRequireWildcard(require(`${undefined}`)));
+Promise.resolve().then(() => _interopRequireWildcard(require(`${null}`)));
+Promise.resolve().then(() => _interopRequireWildcard(require(`${true}`)));
+Promise.resolve().then(() => _interopRequireWildcard(require(`${Symbol()}`)));


### PR DESCRIPTION
Fixes #47.

This uses the `interopRequireWildcard` helper to obtain the module namespace object.