### PR TITLE
Add option for noInterop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,11 @@ export default function ({ template, types: t }) {
           t.identifier('require'),
           [].concat(SOURCE),
         );
+
+        const { noInterop = false } = this.opts;
+        const MODULE = noInterop === true ? requireCall : t.callExpression(this.addHelper('interopRequireWildcard'), [requireCall]);
         const newImport = buildImport({
-          MODULE: t.callExpression(this.addHelper('interopRequireWildcard'), [requireCall]),
+          MODULE,
         });
         path.parentPath.replaceWith(newImport);
       },

--- a/test/fixtures/basic-import/expected.noInterop.js
+++ b/test/fixtures/basic-import/expected.noInterop.js
@@ -1,0 +1,1 @@
+const testModule = Promise.resolve().then(() => require('test-module'));

--- a/test/fixtures/chained-import/expected.noInterop.js
+++ b/test/fixtures/chained-import/expected.noInterop.js
@@ -1,0 +1,3 @@
+Promise.resolve().then(() => require('test-module')).then(() => Promise.resolve().then(() => require('test-module-2')));
+
+Promise.all([Promise.resolve().then(() => require('test-1')), Promise.resolve().then(() => require('test-2')), Promise.resolve().then(() => require('test-3'))]).then(() => {});

--- a/test/fixtures/dynamic-argument/expected.noInterop.js
+++ b/test/fixtures/dynamic-argument/expected.noInterop.js
@@ -1,0 +1,4 @@
+const MODULE = Object('test-module');
+
+Promise.resolve().then(() => require(`${MODULE}`));
+Promise.resolve().then(() => require(`test-${MODULE}`));

--- a/test/fixtures/import-with-comment/expected.noInterop.js
+++ b/test/fixtures/import-with-comment/expected.noInterop.js
@@ -1,0 +1,2 @@
+Promise.resolve().then(() => require('my-module'));
+Promise.resolve().then(() => require('my-module'));

--- a/test/fixtures/nested-import/expected.noInterop.js
+++ b/test/fixtures/nested-import/expected.noInterop.js
@@ -1,0 +1,5 @@
+function getModule(path) {
+  return Promise.resolve().then(() => require('test-module'));
+}
+
+getModule().then(() => {});

--- a/test/fixtures/non-string-argument/expected.noInterop.js
+++ b/test/fixtures/non-string-argument/expected.noInterop.js
@@ -1,0 +1,8 @@
+Promise.resolve().then(() => require(`${{ 'answer': 42 }}`));
+Promise.resolve().then(() => require(`${['foo', 'bar']}`));
+Promise.resolve().then(() => require(`${42}`));
+Promise.resolve().then(() => require(`${void 0}`));
+Promise.resolve().then(() => require(`${undefined}`));
+Promise.resolve().then(() => require(`${null}`));
+Promise.resolve().then(() => require(`${true}`));
+Promise.resolve().then(() => require(`${Symbol()}`));

--- a/test/index.js
+++ b/test/index.js
@@ -16,10 +16,17 @@ test('babel-plugin-dynamic-import-node', (t) => {
     const actual = readFileSync(join(FIXTURE_PATH, folderName, 'actual.js'), 'utf8');
     const expected = readFileSync(join(FIXTURE_PATH, folderName, 'expected.js'), 'utf8');
     const expectedES2015 = readFileSync(join(FIXTURE_PATH, folderName, 'expected.es2015.js'), 'utf8');
+    const expectedNoInterop = readFileSync(join(FIXTURE_PATH, folderName, 'expected.noInterop.js'), 'utf8');
 
     t.test(`works with ${folderName}`, (st) => {
       const result = testPlugin(actual);
       st.equal(result.trim(), expected.trim());
+      st.end();
+    });
+
+    t.test(`works with ${folderName} and the 'noInterop': true option`, (st) => {
+      const result = testPlugin(actual, [], [], { noInterop: true });
+      st.equal(result.trim(), expectedNoInterop.trim());
       st.end();
     });
 

--- a/test/testPlugin.js
+++ b/test/testPlugin.js
@@ -1,9 +1,9 @@
 import { transform } from 'babel-core';
 
-export default function testPlugin(code, presets, plugins) {
+export default function testPlugin(code, presets, plugins, options = {}) {
   const result = transform(code, {
     presets: [].concat(presets || []),
-    plugins: [].concat(plugins || [], './src/index.js'),
+    plugins: [].concat(plugins || [], [['./src/index.js', options]]),
   });
 
   return result.code;


### PR DESCRIPTION
Similar to [babel-plugin-transform-es2015-modules-commonjs](https://github.com/babel/babel/tree/6.x/packages/babel-plugin-transform-es2015-modules-commonjs), allows the user to specify an option for noInterop.

.babelrc
```json
{
  "plugins": [
    ["dynamic-import-node", {"noInterop": true}]
  ]
}
```

In:
```javascript
(async()=>{
  const foo = await import('foo');
})()
```

Out:
```javascript
(async () => {
  const foo = await Promise.resolve().then(() => require('foo'));
})();
```