### PR TITLE
Add option to turn import into synchronous require

### DIFF
--- a/test/fixtures/basic-import/expected.sync.js
+++ b/test/fixtures/basic-import/expected.sync.js
@@ -1,0 +1,3 @@
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+const testModule = _interopRequireWildcard(require('test-module'));

--- a/test/fixtures/chained-import/expected.sync.js
+++ b/test/fixtures/chained-import/expected.sync.js
@@ -1,0 +1,5 @@
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+_interopRequireWildcard(require('test-module')).then(() => _interopRequireWildcard(require('test-module-2')));
+
+Promise.all([_interopRequireWildcard(require('test-1')), _interopRequireWildcard(require('test-2')), _interopRequireWildcard(require('test-3'))]).then(() => {});

--- a/test/fixtures/dynamic-argument/expected.sync.js
+++ b/test/fixtures/dynamic-argument/expected.sync.js
@@ -1,0 +1,6 @@
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+const MODULE = Object('test-module');
+
+_interopRequireWildcard(require(`${MODULE}`));
+_interopRequireWildcard(require(`test-${MODULE}`));

--- a/test/fixtures/import-with-comment/expected.sync.js
+++ b/test/fixtures/import-with-comment/expected.sync.js
@@ -1,0 +1,4 @@
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+_interopRequireWildcard(require('my-module'));
+_interopRequireWildcard(require('my-module'));

--- a/test/fixtures/nested-import/expected.sync.js
+++ b/test/fixtures/nested-import/expected.sync.js
@@ -1,0 +1,7 @@
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+function getModule(path) {
+  return _interopRequireWildcard(require('test-module'));
+}
+
+getModule().then(() => {});

--- a/test/fixtures/non-string-argument/expected.sync.js
+++ b/test/fixtures/non-string-argument/expected.sync.js
@@ -1,0 +1,10 @@
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+_interopRequireWildcard(require(`${{ 'answer': 42 }}`));
+_interopRequireWildcard(require(`${['foo', 'bar']}`));
+_interopRequireWildcard(require(`${42}`));
+_interopRequireWildcard(require(`${void 0}`));
+_interopRequireWildcard(require(`${undefined}`));
+_interopRequireWildcard(require(`${null}`));
+_interopRequireWildcard(require(`${true}`));
+_interopRequireWildcard(require(`${Symbol()}`));

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,7 @@ test('babel-plugin-dynamic-import-node', (t) => {
     const expected = readFileSync(join(FIXTURE_PATH, folderName, 'expected.js'), 'utf8');
     const expectedES2015 = readFileSync(join(FIXTURE_PATH, folderName, 'expected.es2015.js'), 'utf8');
     const expectedNoInterop = readFileSync(join(FIXTURE_PATH, folderName, 'expected.noInterop.js'), 'utf8');
+    const expectedSync = readFileSync(join(FIXTURE_PATH, folderName, 'expected.sync.js'), 'utf8');
 
     t.test(`works with ${folderName}`, (st) => {
       const result = testPlugin(actual);
@@ -27,6 +28,12 @@ test('babel-plugin-dynamic-import-node', (t) => {
     t.test(`works with ${folderName} and the 'noInterop': true option`, (st) => {
       const result = testPlugin(actual, [], [], { noInterop: true });
       st.equal(result.trim(), expectedNoInterop.trim());
+      st.end();
+    });
+
+    t.test(`works with ${folderName} and the 'sync': true option`, (st) => {
+      const result = testPlugin(actual, [], [], { sync: true });
+      st.equal(result.trim(), expectedSync.trim());
       st.end();
     });
 


### PR DESCRIPTION
Adds an option to make `import()` into a synchronous `require()`. Seeing [`babel-plugin-dynamic-import-node-sync`](/seeden/babel-plugin-dynamic-import-node-sync), seems like some people want to use `import()` like this.