### PR TITLE
Handle visiting the same path gracefully

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -18,7 +18,15 @@ export function createDynamicImportTransform({ template, types: t }) {
   const buildImport = template('Promise.resolve(SOURCE).then(s => INTEROP(require(s)))');
   const buildImportNoInterop = template('Promise.resolve(SOURCE).then(s => require(s))');
 
+  const visited = typeof WeakSet === 'function' && new WeakSet();
+
   return (context, path) => {
+    if (visited) {
+      if (visited.has(path)) {
+        return;
+      }
+      visited.add(path);
+    }
     const SOURCE = getImportSource(t, path.parent);
 
     const newImport = context.opts.noInterop


### PR DESCRIPTION
Due to https://github.com/babel/babel/issues/9031 , `babel-plugin-dynamic-import-node` is getting attached twice when using `@babel/register`. This means that the same path is visited twice by this plugin. This ends up trying to import the already modified argument, so this PR ensures we don't try to modify the same path twice.

**Input**
```
const foo = import('foo');
```

**Output**
```
const foo = Promise.resolve().then(() => require(`${() => require('foo')}`));
```

**Output with this PR**
```
const foo = Promise.resolve().then(() => require('path'));
```

You can see the error at this codesandbox:
[![Edit 4z5l3qk0x4](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/4z5l3qk0x4)