### PR TITLE
Export createDynamicImportTransform and getImportSource

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
-export default function ({ template, types: t }) {
-  const buildImport = template('Promise.resolve().then(() => MODULE)');
+import { createDynamicImportTransform } from './utils';
+
+export default function (api) {
+  const transformImport = createDynamicImportTransform(api);
 
   return {
     // NOTE: Once we drop support for Babel <= v6 we should
@@ -11,29 +13,7 @@ export default function ({ template, types: t }) {
 
     visitor: {
       Import(path) {
-        const importArguments = path.parentPath.node.arguments;
-        const [importPath] = importArguments;
-        const isString = t.isStringLiteral(importPath) || t.isTemplateLiteral(importPath);
-        if (isString) {
-          t.removeComments(importPath);
-        }
-        const SOURCE = isString
-          ? importArguments
-          : t.templateLiteral([
-            t.templateElement({ raw: '', cooked: '' }),
-            t.templateElement({ raw: '', cooked: '' }, true),
-          ], importArguments);
-        const requireCall = t.callExpression(
-          t.identifier('require'),
-          [].concat(SOURCE),
-        );
-
-        const { noInterop = false } = this.opts;
-        const MODULE = noInterop === true ? requireCall : t.callExpression(this.addHelper('interopRequireWildcard'), [requireCall]);
-        const newImport = buildImport({
-          MODULE,
-        });
-        path.parentPath.replaceWith(newImport);
+        transformImport(this, path);
       },
     },
   };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,33 @@
+export function getImportSource(t, callNode) {
+  const importArguments = callNode.arguments;
+  const [importPath] = importArguments;
+
+  const isString = t.isStringLiteral(importPath) || t.isTemplateLiteral(importPath);
+  if (isString) {
+    t.removeComments(importPath);
+    return importPath;
+  }
+
+  return t.templateLiteral([
+    t.templateElement({ raw: '', cooked: '' }),
+    t.templateElement({ raw: '', cooked: '' }, true),
+  ], importArguments);
+}
+
+export function createDynamicImportTransform({ template, types: t }) {
+  const buildImport = template('Promise.resolve().then(() => MODULE)');
+
+  return (context, path) => {
+    const requireCall = t.callExpression(
+      t.identifier('require'),
+      [getImportSource(t, path.parent)],
+    );
+
+    const { noInterop = false } = context.opts;
+    const MODULE = noInterop === true ? requireCall : t.callExpression(context.addHelper('interopRequireWildcard'), [requireCall]);
+    const newImport = buildImport({
+      MODULE,
+    });
+    path.parentPath.replaceWith(newImport);
+  };
+}

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,6 @@
+// Re-export lib/utils, so that consumers can import
+// babel-plugin-dynamic-import-node/utils instead of
+// babel-plugin-dynamic-import-node/lib/utils
+
+// eslint-disable-next-line import/no-unresolved
+module.exports = require('./lib/utils');


### PR DESCRIPTION
I'd be very grateful if you could expose your internal transformation logic to use it in `@babel/plugin-proposal-dynamic-import`, which will then be used in `@babel/preset-env`. (I will mention in the docs that, when targeting commonjs, it internally uses this plugin).

Currently I'm working it around by doing this, but it is unnecessarily too hacky: [link](https://github.com/babel/babel/blob/97b0ac41acb32cf301dbb4110243d9607d99f8a7/packages/babel-plugin-transform-modules-commonjs/src/index.js#L19-L21)
```js
  const transformImportCall = Function.call.bind(
    babelPluginDynamicImportNode(api).visitor.Import,
  );
```

Commit message:

> While working on babel/babel#9552, I realized I needed two functions:
> - createDynamicImportTransform is basically all what this plugin
>   does, but it can be invoked directly.
> - getImportSource is needed to re-use the same import argument
>   stringifying logic for the AMD and SystemJS transforms
> 
> I added those functions as named exports of the main entry point,
> but I had some compatibility problems because the "add-module-exports"
> babel plugin automatically disables itself when there is a named
> export. I resolved it by removing that plugin and manually writing
> module.exports in the source file.
> I couldn't disable the modules transform in the "airbnb" preset because
> "transform-replace-object-assign" (v0.2.x) always injects import
> declarations, even if "sourceType" is "script".

If you prefer not to have `module.exports` in the source file, I could create two separate entry points: `babel-plugin-dynamic-import-node` and `babel-plugin-dynamic-import-node/utils`, and export those new functions from the second one. I think that the current implementation is nicer.

NOTE: This isn't blocking the Babel release, since the workaround is working for now. I can't use `getImportSource` for AMD yet, but it is a minor problem.