### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Babel plugin to transpile `import()` to a deferred `require()`, for node. Matches the [proposed spec](https://github.com/domenic/proposal-import-function).
 
-**NOTE:** Babylon >= v6.12.0 is required to correctly parse dynamic imports.
+**NOTE:** Babel >= v6.12.0 is required to correctly parse dynamic imports.
 
 ## Installation
 


### PR DESCRIPTION
Seems like you misspelled `Babel` in the README.