### PR TITLE
Drop object.assign dependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,6 @@
     "airbnb"
   ],
   "plugins": [
-    "add-module-exports"
+    "add-module-exports",
   ],
 }

--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,6 @@
     "airbnb"
   ],
   "plugins": [
-    "add-module-exports",
-    ["transform-replace-object-assign", { "moduleSpecifier": "object.assign" }],
+    "add-module-exports"
   ],
 }

--- a/package.json
+++ b/package.json
@@ -59,8 +59,5 @@
     "rimraf": "^2.6.3",
     "safe-publish-latest": "^1.1.2",
     "tape": "^4.10.2"
-  },
-  "dependencies": {
-    "object.assign": "^4.1.0"
   }
 }


### PR DESCRIPTION
All non-deprecated versions of Node.js now have native Object.assign.